### PR TITLE
Bump Upper-Bounds for `tasty`

### DIFF
--- a/bytebuild.cabal
+++ b/bytebuild.cabal
@@ -96,7 +96,7 @@ test-suite test
     , quickcheck-classes >=0.6.4
     , quickcheck-instances >=0.3.22
     , text-short
-    , tasty >=1.2.3 && <1.3
+    , tasty >=1.2.3 && <1.5
     , tasty-hunit >=0.10.0.2 && <0.11
     , tasty-quickcheck >=0.10.1 && <0.11
     , text >=1.2 && <1.3


### PR DESCRIPTION
Hi, I'm in the process of bringing some of our dependencies into Stackage. The upper bounds for `tasty` is currently preventing bringing in `bytebuild`.

This PR bumps the upper bound so we can build against the latest version, `1.4.2.1`. The package now successfully builds on LTS 18, 19, & Nightly(with some `extra-deps` for other packages I'm bringing into Stackage).

Would appreciate a new release after merging, I can then make the MR to bring this in as well.