### PR TITLE
build with primitive 0.8

### DIFF
--- a/bytebuild.cabal
+++ b/bytebuild.cabal
@@ -18,7 +18,7 @@ description:
   that runs out of space simply aborts and is rerun at the beginning
   of the next chunk. This strategy for building is suitable for most
   CSVs and several line protocols (carbon, InfluxDB, etc.).
-  
+
 homepage: https://github.com/byteverse/bytebuild
 bug-reports: https://github.com/byteverse/bytebuild/issues
 license: BSD-3-Clause
@@ -68,10 +68,10 @@ library
     if impl(ghc >= 8.10)
       hs-source-dirs: src-9.0
   if flag(checked)
-    build-depends: primitive-checked >= 0.7 && <0.8
+    build-depends: primitive-checked >= 0.7 && <0.9
     hs-source-dirs: src-checked
   else
-    build-depends: primitive >= 0.7 && <0.8
+    build-depends: primitive >= 0.7 && <0.9
     hs-source-dirs: src-unchecked
   ghc-options: -Wall -O2
   hs-source-dirs: src


### PR DESCRIPTION
```
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=byteslice:primitive --allow-newer=primitive-addr:primitive --allow-newer=primitive-unlifted:primitive --allow-newer=run-st:primitive --allow-newer=wide-word:primitive --allow-newer=tuples:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - byteslice-0.2.9.0 (lib) (requires build)
 - haskell-src-exts-1.23.1 (lib) (requires build)
 - primitive-offset-0.2.0.0 (lib) (requires build)
 - haskell-src-meta-0.8.11 (lib) (requires build)
 - bytebuild-0.3.11.0 (lib) (first run)
Starting     byteslice-0.2.9.0 (lib)
Starting     primitive-offset-0.2.0.0 (lib)
Starting     haskell-src-exts-1.23.1 (lib)
Building     primitive-offset-0.2.0.0 (lib)
Building     byteslice-0.2.9.0 (lib)
Building     haskell-src-exts-1.23.1 (lib)
Installing   primitive-offset-0.2.0.0 (lib)
Completed    primitive-offset-0.2.0.0 (lib)
Installing   byteslice-0.2.9.0 (lib)
Completed    byteslice-0.2.9.0 (lib)
Installing   haskell-src-exts-1.23.1 (lib)
Completed    haskell-src-exts-1.23.1 (lib)
Starting     haskell-src-meta-0.8.11 (lib)
Building     haskell-src-meta-0.8.11 (lib)
Installing   haskell-src-meta-0.8.11 (lib)
Completed    haskell-src-meta-0.8.11 (lib)
Configuring library for bytebuild-0.3.11.0..
Preprocessing library for bytebuild-0.3.11.0..
Building library for bytebuild-0.3.11.0..
[1 of 9] Compiling Compat           ( src-9.2/Compat.hs, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Compat.o, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Compat.dyn_o )
[2 of 9] Compiling Data.Bytes.Builder.Bounded.Unsafe ( src/Data/Bytes/Builder/Bounded/Unsafe.hs, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Bounded/Unsafe.o, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Bounded/Unsafe.dyn_o )
[3 of 9] Compiling Data.Bytes.Builder.Bounded ( src/Data/Bytes/Builder/Bounded.hs, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Bounded.o, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Bounded.dyn_o )
[4 of 9] Compiling Data.Bytes.Builder.Bounded.Class ( src/Data/Bytes/Builder/Bounded/Class.hs, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Bounded/Class.o, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Bounded/Class.dyn_o )
[5 of 9] Compiling Op               ( src-unchecked/Op.hs, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Op.o, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Op.dyn_o )
[6 of 9] Compiling Data.Bytes.Builder.Unsafe ( src/Data/Bytes/Builder/Unsafe.hs, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Unsafe.o, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Unsafe.dyn_o )
[7 of 9] Compiling Data.Bytes.Builder ( src/Data/Bytes/Builder.hs, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder.o, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder.dyn_o )
[8 of 9] Compiling Data.Bytes.Builder.Class ( src/Data/Bytes/Builder/Class.hs, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Class.o, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Class.dyn_o )
[9 of 9] Compiling Data.Bytes.Builder.Template ( src/Data/Bytes/Builder/Template.hs, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Template.o, /home/chessai/haskell/bytebuild/dist-newstyle/build/x86_64-linux/ghc-9.4.4/bytebuild-0.3.11.0/build/Data/Bytes/Builder/Template.dyn_o )
```