### PR TITLE
Allow base 4.18.0.0

### DIFF
--- a/bytebuild.cabal
+++ b/bytebuild.cabal
@@ -49,7 +49,7 @@ library
   reexported-modules:
     Data.Bytes.Chunks
   build-depends:
-    , base >=4.12.0.0 && <4.18
+    , base >=4.12.0.0 && <4.19
     , byteslice >=0.2.6 && <0.3
     , bytestring >=0.10.8.2 && <0.12
     , haskell-src-meta >=0.8


### PR DESCRIPTION
Update bytebuild.cabal to include base 4.18 in bounds in order to support ghc 9.6. Tested locally with `cabal test -w ghc-9.6 --constraint 'base==4.18.0.0' --allow-newer='zigzag:base'`. Would love if we could have a metadata revision after merging. Depends on https://github.com/byteverse/zigzag/pull/2 which updates base bounds for zigzag.