### PR TITLE
Bump upper bounds for `tasty`

### DIFF
--- a/bytebuild.cabal
+++ b/bytebuild.cabal
@@ -99,7 +99,7 @@ test-suite test
     , quickcheck-classes >=0.6.4
     , quickcheck-instances >=0.3.22
     , text-short
-    , tasty >=1.2.3 && <1.5
+    , tasty >=1.2.3 && <1.6
     , tasty-hunit >=0.10.0.2 && <0.11
     , tasty-quickcheck >=0.10.1 && <0.11
     , text >=1.2 && <2.2


### PR DESCRIPTION
Hi, I was asked to bump the bounds for `tasty` in this request: https://github.com/commercialhaskell/stackage/issues/7111

Bumps upper bounds for `tasty` to allow `1.5` in test-suite. I ran the test suite locally. Would love if we could have a metadata revision after merging. Thanks!